### PR TITLE
Make building for 64bit explicit

### DIFF
--- a/tree-sitter/Makefile
+++ b/tree-sitter/Makefile
@@ -3,7 +3,7 @@
 #	Tree-Sitter Base and Common Language Parsers
 #
 
-CFLAGS=/nologo /FC /Od /Z7 /Gy /diagnostics:column /Itree-sitter/lib/include
+CFLAGS=/nologo /FC /Od /Z7 /Gy /diagnostics:column /Itree-sitter/lib/include /favor:INTEL64
 LFLAGS=/def:$(@B).def /incremental:no /debug
 
 BIN=..\src\bin\debug\net7.0


### PR DESCRIPTION
I was building treesitter with the default VS tooling with a 32bit version of the compiler. By adding this flag you will get build errors when compiling with the 32bit version because it can not build the 64bit assemblies needed for .net core. This will make it clear for the person that builds the tree-sitter dll that the wrong version of the compiler is used