### PR TITLE
Drop the binaries in the correct output directory

### DIFF
--- a/tree-sitter/Makefile
+++ b/tree-sitter/Makefile
@@ -6,7 +6,7 @@
 CFLAGS=/nologo /FC /Od /Z7 /Gy /diagnostics:column /Itree-sitter/lib/include
 LFLAGS=/def:$(@B).def /incremental:no /debug
 
-BIN=..\src\bin\debug\net7.0
+BIN=..\bin\debug\net7.0
 
 DLLS=\
 	$(BIN)/tree-sitter.dll \


### PR DESCRIPTION
Drop the binaries in the correct output directory

- these are the compiled tree-siter binaries
- the corrected directory matches the output directory of the .net build